### PR TITLE
Enable environment vars for the Google API key

### DIFF
--- a/src/templates/_components/fields/EntryCoordinates_settings.twig
+++ b/src/templates/_components/fields/EntryCoordinates_settings.twig
@@ -17,10 +17,11 @@
 
 {% do view.registerAssetBundle("nthmedia\\entrygpscoordinates\\assetbundles\\entrycoordinatesfield\\EntryCoordinatesFieldAsset") %}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: 'Google API Key',
     instructions: 'Enter your Google API key here. It needs permission to access "Maps JavaScript API" and "Places API".',
     id: 'googleApiKey',
     name: 'googleApiKey',
-    value: field['googleApiKey']})
+    value: field['googleApiKey'],
+    suggestEnvVars: true})
 }}


### PR DESCRIPTION
Allows the Google API key field to use environment variables located in .env