### PR TITLE
Parse env var

### DIFF
--- a/src/fields/EntryCoordinates.php
+++ b/src/fields/EntryCoordinates.php
@@ -376,7 +376,7 @@ class EntryCoordinates extends Field
                 'id' => $id,
                 'namespacedId' => $namespacedId,
 
-                'googleApiKey' => $this->googleApiKey
+                'googleApiKey' => Craft::parseEnv($this->googleApiKey)
             ]
         );
     }


### PR DESCRIPTION
Bug fix to parse the `googleApiKey` field setting for environment variables before outputting the input field.